### PR TITLE
fix(pooler): serviceTemplate integration

### DIFF
--- a/charts/cluster/Chart.yaml
+++ b/charts/cluster/Chart.yaml
@@ -18,7 +18,7 @@ name: cluster
 description: Deploys and manages a CloudNativePG cluster and its associated resources.
 icon: https://raw.githubusercontent.com/cloudnative-pg/artwork/main/cloudnativepg-logo.svg
 type: application
-version: 0.3.1
+version: 0.3.2
 sources:
   - https://github.com/cloudnative-pg/charts
 keywords:

--- a/charts/cluster/templates/pooler.yaml
+++ b/charts/cluster/templates/pooler.yaml
@@ -46,7 +46,9 @@ spec:
   template:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
-  {{- with serviceTemplate }}
+  {{- with .serviceTemplate }}
   serviceTemplate:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
+{{- end }}
+


### PR DESCRIPTION
In [PR 595](https://github.com/cloudnative-pg/charts/pull/595) the pooler template doesn't work as expected and templating it with helm returns an error `function "serviceTemplate" not defined`
Also it seems a closing `{{- end }}` was missing
Hopefully this could eventually be merged into the official chart